### PR TITLE
macos: Use first window when mainWindow is nil

### DIFF
--- a/macos/Classes/DesktopWindowPlugin.swift
+++ b/macos/Classes/DesktopWindowPlugin.swift
@@ -9,7 +9,8 @@ public class DesktopWindowPlugin: NSObject, FlutterPlugin {
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    if let window = NSApplication.shared.mainWindow {
+    let firstWindow = NSApplication.shared.windows.isEmpty ? nil : NSApplication.shared.windows[0]
+    if let window = NSApplication.shared.mainWindow ?? firstWindow {
       switch call.method {
 
       case "getWindowSize":


### PR DESCRIPTION
On macOS, it doesn't work when the window is inactive.
Resolve it by using first window when mainWindow is nil.